### PR TITLE
♻️  Refactor: viewTab과 subscribedToggle 상태 변경

### DIFF
--- a/src/components/Media/MediaSection/index.jsx
+++ b/src/components/Media/MediaSection/index.jsx
@@ -1,8 +1,18 @@
 import GridView from './GridView';
 import ListView from './ListView';
 
-const MediaSection = ({ isListView }) => {
-  return <> {isListView ? <ListView /> : <GridView />} </>;
+const MediaSection = ({ viewType }) => {
+  function getViewComponent(type) {
+    const map = {
+      list: ListView,
+      grid: GridView,
+    };
+    return map[type];
+  }
+
+  const ViewComponet = getViewComponent(viewType);
+
+  return <ViewComponet />;
 };
 
 export default MediaSection;

--- a/src/components/Media/MediaTab/TabList/index.jsx
+++ b/src/components/Media/MediaTab/TabList/index.jsx
@@ -6,17 +6,17 @@ const StyledTabList = styled.div`
   gap: 16px;
 `;
 
-const TabList = ({ isSubscribedTab, setIsSubscribedTab }) => {
+const TabList = ({ tabType, setTabType }) => {
   return (
     <StyledTabList>
       <TabItem
-        isActive={!isSubscribedTab}
-        onClick={() => setIsSubscribedTab(false)}
+        isActive={tabType === 'all'}
+        onClick={() => setTabType('all')}
         label="전체 언론사"
       />
       <TabItem
-        isActive={isSubscribedTab}
-        onClick={() => setIsSubscribedTab(true)}
+        isActive={tabType === 'subscribed'}
+        onClick={() => setTabType('subscribed')}
         label="내가 구독한 언론사"
         badgeLabel="8"
       />

--- a/src/components/Media/MediaTab/ViewModeToggle/index.jsx
+++ b/src/components/Media/MediaTab/ViewModeToggle/index.jsx
@@ -6,18 +6,18 @@ const StyledViewModeToggle = styled.div`
   gap: 8px;
 `;
 
-const ViewModeToggle = ({ isListView, setIsListView }) => {
+const ViewModeToggle = ({ viewType, setViewType }) => {
   return (
     <StyledViewModeToggle>
       <ViewButton
         type="list"
-        isActive={isListView}
-        onClick={() => setIsListView(true)}
+        isActive={viewType === 'list'}
+        onClick={() => setViewType('list')}
       />
       <ViewButton
         type="grid"
-        isActive={!isListView}
-        onClick={() => setIsListView(false)}
+        isActive={viewType === 'grid'}
+        onClick={() => setViewType('grid')}
       />
     </StyledViewModeToggle>
   );

--- a/src/components/Media/MediaTab/index.jsx
+++ b/src/components/Media/MediaTab/index.jsx
@@ -10,19 +10,11 @@ const TabBarContainer = styled.div`
   height: 40px;
 `;
 
-const MediaTab = ({
-  isSubscribedTab,
-  setIsSubscribedTab,
-  isListView,
-  setIsListView,
-}) => {
+const MediaTab = ({ tabType, setTabType, viewType, setViewType }) => {
   return (
     <TabBarContainer>
-      <TabList
-        isSubscribedTab={isSubscribedTab}
-        setIsSubscribedTab={setIsSubscribedTab}
-      />
-      <ViewModeToggle isListView={isListView} setIsListView={setIsListView} />
+      <TabList tabType={tabType} setTabType={setTabType} />
+      <ViewModeToggle viewType={viewType} setViewType={setViewType} />
     </TabBarContainer>
   );
 };

--- a/src/components/Media/index.jsx
+++ b/src/components/Media/index.jsx
@@ -11,18 +11,18 @@ const MediaContainer = styled.div`
 `;
 
 const Media = () => {
-  const [isSubscribedTab, setIsSubscribedTab] = useState(false);
-  const [isListView, setIsListView] = useState(false);
+  const [tabType, setTabType] = useState('all');
+  const [viewType, setViewType] = useState('grid');
 
   return (
     <MediaContainer>
       <MediaTab
-        isSubscribedTab={isSubscribedTab}
-        setIsSubscribedTab={setIsSubscribedTab}
-        isListView={isListView}
-        setIsListView={setIsListView}
+        tabType={tabType}
+        setTabType={setTabType}
+        viewType={viewType}
+        setViewType={setViewType}
       />
-      <MediaSection isListView={isListView} />
+      <MediaSection viewType={viewType} />
     </MediaContainer>
   );
 };


### PR DESCRIPTION
### 🔧 변경사항

- **불리언 기반의 `viewType`, `tabType` 상태를 문자열 기반으로 변경**
  - `isListView → viewType: 'list' | 'grid'`  
  - `isSubscribedTab → tabType: 'all' | 'subscribed'`
- **상태 값의 의미를 명확히 표현할 수 있어 가독성 및 확장성 향상**
- **자식 컴포넌트에 prop을 넘길 때 조건 처리 명확**
  - 예: `isActive={viewType === 'list'}`

---

### 🧠 변경 이유

- **boolean 값은 상태의 의미를 직관적으로 표현하기 어려움**
  → string 값을 사용하면 코드만 봐도 어떤 상태인지 쉽게 이해 가능
- **컴포넌트 확장성 증가**
  → `'list' | 'grid'` 외에 `'carousel'`, `'compact'` 등으로 확장 가능
- **로직 분기 및 스타일링 시 명확한 조건 작성이 가능**
---

### 주요 고민과 해결 과정

### **ViewButton의 활성화 상태를 어디서 판단할 것인가?**

#### 🧐 고민의 배경

`ViewModeToggle` 컴포넌트에서 `<ViewButton />`을 렌더링할 때, 현재 어떤 뷰 타입이 선택되었는지에 따라 버튼 스타일을 변경해야 했습니다.

초기에는 자식 컴포넌트에서 `type`과 `selectedType`을 받아 `isActive`를 스스로 판단하도록 구현할지, 아니면 부모에서 `isActive`를 계산해서 내려줄지를 두고 고민했습니다.

#### 고려한 방식

| 방식 | 설명 | 장점 | 단점 |
|------|------|------|------|
| 1. 자식 내부에서 `selectedType === type`으로 직접 비교 | ViewButton에서 직접 로직 처리 | - 부모 컴포넌트가 간결<br/>- 내부 확장에 유리 | - 자식이 상태 구조를 알아야 함<br/>- 부모 상태 변경 시 자식도 수정 필요 |
| 2. 부모에서 `isActive` 계산 후 전달 | `isActive={viewType === 'list'}`처럼 boolean 전달 | - 관심사 분리 명확<br/>- 자식은 렌더링만 담당<br/>- 상태 구조 변경에 유연 | - 여러 버튼일 경우 조건식 반복 발생 가능 |

#### ✨ 깨달은 점

> 자식이 로직을 갖지 않고 단순히 `isActive`만 받아 스타일만 처리한다면,  
> 부모에서 상태 구조가 변경되더라도 **자식은 수정할 필요가 없다.**

- 이는 곧 **자식의 추상화 수준을 일정하게 유지**한다는 뜻
- `boolean`에서 `string`으로 상태 구조가 바뀌더라도 ViewButton은 영향을 받지 않음
- **컴포넌트 책임이 명확**해지고, **변화에 강한 구조**가 됨

#### ✅ 최종 해결

> **부모 컴포넌트에서 `isActive`를 계산하여 자식에게 넘기는 방식**을 선택했습니다.

```jsx
<ViewButton
  type="list"
  isActive={viewType === 'list'}
  onClick={() => setViewType('list')}
/>