### PR TITLE
🐛 Fix: import external 간의 줄바꿈이 일어나던 문제 해결

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,18 +46,13 @@ export default [
           ],
           pathGroups: [
             {
-              pattern: '@emotion/**',
-              group: 'external',
-              position: 'after',
-            },
-            {
               pattern: '@/**',
               group: 'internal',
               position: 'after',
             },
           ],
           pathGroupsExcludedImportTypes: ['builtin'],
-          'newlines-between': 'never', // 그룹 간 줄바꿈
+          'newlines-between': 'always', // 그룹 간 줄바꿈
           alphabetize: {
             order: 'asc', // 알파벳순 정렬
             caseInsensitive: true,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
+
 import StackLayout from '@components/common/layout';
 import Header from '@components/Header';
 import Media from '@components/Media';

--- a/src/components/Header/BrandSection/index.jsx
+++ b/src/components/Header/BrandSection/index.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import NewsPaperIcon from '@/assets/icons/newspaper.svg?react';
 
 const StyledBrandSection = styled.div`

--- a/src/components/Header/DateDisplay/index.jsx
+++ b/src/components/Header/DateDisplay/index.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
-import { useMemo } from 'react';
 import styled from '@emotion/styled';
+import { useMemo } from 'react';
+
 import getFormattedToday from '@/utils/getFormattedToday';
 
 const DateDisplay = styled.div`

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
+
 import BrandSection from './BrandSection';
 import DateDisplay from './DateDisplay';
 

--- a/src/components/Media/MediaTab/TabList/TabItem.jsx
+++ b/src/components/Media/MediaTab/TabList/TabItem.jsx
@@ -1,6 +1,7 @@
 // components/TabItem.jsx
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
+
 import Badge from '@components/common/Badge';
 
 const StyledTabItem = styled.button`

--- a/src/components/Media/MediaTab/TabList/index.jsx
+++ b/src/components/Media/MediaTab/TabList/index.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import TabItem from './TabItem';
 
 const StyledTabList = styled.div`

--- a/src/components/Media/MediaTab/ViewModeToggle/ViewButton.jsx
+++ b/src/components/Media/MediaTab/ViewModeToggle/ViewButton.jsx
@@ -1,6 +1,7 @@
 // components/TabItem.jsx
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
+
 import GridIcon from '@/assets/icons/grid-view.svg?react';
 import ListIcon from '@/assets/icons/list-view.svg?react';
 

--- a/src/components/Media/MediaTab/ViewModeToggle/index.jsx
+++ b/src/components/Media/MediaTab/ViewModeToggle/index.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import ViewButton from './ViewButton';
 
 const StyledViewModeToggle = styled.div`

--- a/src/components/Media/MediaTab/index.jsx
+++ b/src/components/Media/MediaTab/index.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import TabList from './TabList';
 import ViewModeToggle from './ViewModeToggle';
 

--- a/src/components/Media/index.jsx
+++ b/src/components/Media/index.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
 import styled from '@emotion/styled';
+import { useState } from 'react';
+
 import MediaSection from './MediaSection';
 import MediaTab from './MediaTab';
 

--- a/src/components/NewsRolling/RollingItem.jsx
+++ b/src/components/NewsRolling/RollingItem.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import styled from '@emotion/styled';
+import React from 'react';
 
 const RollingItemContainer = styled.div`
   width: 100%;

--- a/src/components/NewsRolling/index.jsx
+++ b/src/components/NewsRolling/index.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import RollingItem from './RollingItem';
 
 const NewsRollingContainer = styled.div`

--- a/src/components/Theme/ThemeProvider.jsx
+++ b/src/components/Theme/ThemeProvider.jsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
+
 import { GlobalStyle } from '@/styles/GlobalStyle';
+
 import { darkTheme, lightTheme } from './themes';
 
 export default function ThemeProvider({ children, isDarkMode }) {

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import ClosedIcon from '@/assets/icons/closed.svg?react';
 import PlusIcon from '@/assets/icons/plus.svg?react';
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+
 import App from './App.jsx';
 
 //entry point(root) 요소 생성해서 render시키기

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
-import emotionReset from 'emotion-reset';
 import { Global, css } from '@emotion/react';
+import emotionReset from 'emotion-reset';
 
 const globalStyles = (theme) => css`
   ${emotionReset}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';


### PR DESCRIPTION
### ❗ 문제
- React와 Emotion은 모두 external 모듈임에도 ESLint import 정렬 시 줄바꿈이 발생하던 문제

### 🧠 원인
- pathGroups에 `@emotion/**`를 별도 명시하면 ESLint가 react와 emotion을 서로 다른 그룹처럼 분류함

### ✅ 해결
- pathGroups에서 `@emotion/**` 설정 제거
- ESLint가 emotion을 기본 external로 인식하게 되어 React와 같은 그룹으로 정렬됨
- 그룹 간 줄바꿈(`newlines-between: 'always'`)은 유지하면서 React → Emotion 순서로 붙어 정렬됨

### 🧼 결과
- 가독성 향상
- 일관된 import 구조 유지
