### PR TITLE
✨feat: 구독 해지 모달 컴포넌트 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 
-import Alert from '@components/common/Alert';
 import StackLayout from '@components/common/layout';
+import Modal from '@components/common/Modal';
 import Header from '@components/Header';
-import Media from '@components/Media';
 import NewsRolling from '@components/NewsRolling';
 import DarkModeToggle from '@components/Theme/DarkModeToggle';
 import ThemeProvider from '@components/Theme/ThemeProvider';
@@ -31,7 +30,7 @@ function App() {
         <button onClick={() => setIsModalOpen(true)}>버튼</button>
       </StackLayout>
       {isModalOpen && (
-        <Alert
+        <Modal
           mediaName={targetItem}
           isModalOpen={isModalOpen}
           handleClose={handleClose}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 
+import Alert from '@components/common/Alert';
 import StackLayout from '@components/common/layout';
 import Header from '@components/Header';
 import Media from '@components/Media';
@@ -10,9 +11,15 @@ import ThemeProvider from '@components/Theme/ThemeProvider';
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [targetItem, setTargetItem] = useState('연합뉴스');
 
   const toggleTheme = () => {
     setIsDarkMode((prev) => !prev);
+  };
+
+  const handleClose = () => {
+    setIsModalOpen(false); // 모달 닫기
   };
 
   return (
@@ -21,8 +28,15 @@ function App() {
         <DarkModeToggle isDarkMode={isDarkMode} onToggle={toggleTheme} />
         <Header />
         <NewsRolling />
-        <Media />
+        <button onClick={() => setIsModalOpen(true)}>버튼</button>
       </StackLayout>
+      {isModalOpen && (
+        <Alert
+          mediaName={targetItem}
+          isModalOpen={isModalOpen}
+          handleClose={handleClose}
+        />
+      )}
     </ThemeProvider>
   );
 }

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -1,1 +1,103 @@
-//Arert component
+import styled from '@emotion/styled';
+import { useEffect } from 'react';
+
+const AlertContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`;
+
+const AlertContent = styled.div`
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.surface.default};
+  border: 1px solid ${({ theme }) => theme.colors.border.default};
+  border-bottom: none;
+  box-shadow: ${({ theme }) => theme.shadow.popup};
+`;
+
+const TitleGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  color: ${({ theme }) => theme.colors.text.default};
+  ${({ theme }) => theme.typography.m16};
+`;
+
+const StyledText = styled.span`
+  color: ${({ theme }) => theme.colors.text.strong};
+  ${({ theme }) => theme.typography.b16};
+`;
+
+const ButtonGroup = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  border-top: 1px solid ${({ theme }) => theme.colors.border.default};
+  gap: 1px;
+  background-color: ${({ theme }) => theme.colors.border.default};
+`;
+
+const Button = styled.button`
+  width: 100%;
+  padding: 10px 20px;
+  border: none;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.colors.surface.alt};
+  color: ${({ emphasized, theme }) =>
+    emphasized ? theme.colors.text.strong : theme.colors.text.default};
+
+  ${({ theme }) => theme.typography.m16};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const Alert = ({ mediaName, isModalOpen, handleClose }) => {
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isModalOpen]);
+
+  return (
+    <AlertContainer>
+      <AlertContent>
+        <TitleGroup>
+          <p>
+            <StyledText>{mediaName}</StyledText>을(를)
+          </p>
+          <p>구독해지하시겠습니까?</p>
+        </TitleGroup>
+        <ButtonGroup>
+          <Button onClick={handleClose}>예, 해지합니다</Button>
+          <Button emphasized onClick={handleClose}>
+            아니오
+          </Button>
+        </ButtonGroup>
+      </AlertContent>
+    </AlertContainer>
+  );
+};
+
+export default Alert;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 
-const AlertContainer = styled.div`
+const ModalContainer = styled.div`
   width: 100vw;
   height: 100vh;
   display: flex;
@@ -17,7 +17,7 @@ const AlertContainer = styled.div`
   z-index: 1000;
 `;
 
-const AlertContent = styled.div`
+const ModalContent = styled.div`
   width: 320px;
   display: flex;
   flex-direction: column;
@@ -67,7 +67,7 @@ const Button = styled.button`
   }
 `;
 
-const Alert = ({ mediaName, isModalOpen, handleClose }) => {
+const Modal = ({ mediaName, isModalOpen, handleClose }) => {
   useEffect(() => {
     if (isModalOpen) {
       document.body.style.overflow = 'hidden';
@@ -81,8 +81,8 @@ const Alert = ({ mediaName, isModalOpen, handleClose }) => {
   }, [isModalOpen]);
 
   return (
-    <AlertContainer>
-      <AlertContent>
+    <ModalContainer>
+      <ModalContent>
         <TitleGroup>
           <p>
             <StyledText>{mediaName}</StyledText>을(를)
@@ -95,9 +95,9 @@ const Alert = ({ mediaName, isModalOpen, handleClose }) => {
             아니오
           </Button>
         </ButtonGroup>
-      </AlertContent>
-    </AlertContainer>
+      </ModalContent>
+    </ModalContainer>
   );
 };
 
-export default Alert;
+export default Modal;


### PR DESCRIPTION
## 🔧 구현 기능

- **구독 해지 모달 컴포넌트 구현**
  - 사용자가 **구독 해지 버튼**을 눌렀을 때 나타나는 **모달 UI 컴포넌트**를 구현했습니다.
  - 해지 대상인 `media` 이름을 **props로 전달받아**, 모달 내에 **동적으로 노출**되도록 처리했습니다.

---

## 🤔 고민한 부분 및 해결 방식

1. **Border가 겹치는 문제**
   - 컴포넌트 간 **border 이중 겹침 현상**을 줄이기 위해:
     - 요소 사이에 `gap: 1px`을 주고, 해당 `gap`의 **배경색을 border 색상**과 동일하게 지정해 시각적으로 자연스럽게 처리했습니다.

2. **모달이 열릴 때 배경 스크롤 방지**
   - `document.body.style.overflow = 'hidden'`을 사용해 **스크롤을 막는 방식**을 적용했습니다.
   - 하지만 모달이 닫힌 후에도 `overflow: hidden`이 **지속되는 문제**가 있어,
     - `useEffect` 내에서 **모달의 열림 상태를 의존성 배열**에 넣고, 상태 변화에 따라 `overflow` 값을 정확하게 **복원**하도록 해결했습니다.