### PR TITLE
💄style : reset.css 적용 및 List View 레이아웃 안정화

### DIFF
--- a/src/components/Media/MediaSection/GridView/GridView.jsx
+++ b/src/components/Media/MediaSection/GridView/GridView.jsx
@@ -24,7 +24,6 @@ const TableCell = styled.td`
     left: 50%;
     transform: translate(-50%, -50%);
     opacity: 0;
-    cursor: pointer;
   }
 
   &:hover {

--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -10,7 +10,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  box-sizing: border-box;
 `;
 
 const PressNews = styled.div`

--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -10,6 +10,8 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 388px;
+  border: 1px solid ${({ theme }) => theme.colors.border.default};
 `;
 
 const PressNews = styled.div`
@@ -17,9 +19,7 @@ const PressNews = styled.div`
   flex-direction: column;
   gap: 12px;
   padding: 24px;
-
-  border: 1px solid ${({ theme }) => theme.colors.border.default};
-  border-top: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.border.default};
 `;
 
 const News = styled.div`

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -14,9 +14,7 @@ const StyledButton = styled.button`
   align-items: center;
   height: 100%;
   padding: 11.5px 16px;
-  border: none;
   font-size: 14px;
-  cursor: pointer;
   background-color: ${({ theme, isActive }) =>
     isActive ? theme.colors.surface.brandAlt : theme.colors.surface.alt};
 

--- a/src/components/Media/MediaTab/TabList/TabItem.jsx
+++ b/src/components/Media/MediaTab/TabList/TabItem.jsx
@@ -9,10 +9,6 @@ const StyledTabItem = styled.button`
   align-items: center;
   font-size: 14px;
   font-weight: 500;
-  background: none;
-  padding: 0;
-  border: none;
-  cursor: pointer;
 
   color: ${({ theme, isActive }) =>
     isActive ? theme.colors.text.strong : theme.colors.text.weak};

--- a/src/components/Media/MediaTab/ViewModeToggle/ViewButton.jsx
+++ b/src/components/Media/MediaTab/ViewModeToggle/ViewButton.jsx
@@ -8,10 +8,6 @@ import ListIcon from '@/assets/icons/list-view.svg?react';
 const StyledViewButton = styled.button`
   width: 24px;
   height: 24px;
-  background: none;
-  padding: 0;
-  border: none;
-  cursor: pointer;
 
   color: ${({ theme, isActive }) =>
     isActive ? theme.colors.text.point : theme.colors.text.weak};

--- a/src/components/NewsRolling/RollingItem.jsx
+++ b/src/components/NewsRolling/RollingItem.jsx
@@ -6,7 +6,6 @@ const Wrapper = styled.div`
   height: 49px;
   overflow: hidden;
   position: relative;
-  box-sizing: border-box;
   border: 1px solid ${({ theme }) => theme.colors.border.default};
 `;
 

--- a/src/components/Theme/DarkModeToggle.jsx
+++ b/src/components/Theme/DarkModeToggle.jsx
@@ -3,10 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 const ToggleButton = styled.button`
-  background: none;
-  border: none;
   font-size: 2rem;
-  cursor: pointer;
   transition: transform 0.3s ease;
   padding: 0.5rem;
   border-radius: 50%;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -54,8 +54,6 @@ const ButtonGroup = styled.div`
 const Button = styled.button`
   width: 100%;
   padding: 10px 20px;
-  border: none;
-  cursor: pointer;
   background-color: ${({ theme }) => theme.colors.surface.alt};
   color: ${({ emphasized, theme }) =>
     emphasized ? theme.colors.text.strong : theme.colors.text.default};

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -1,13 +1,173 @@
 /** @jsxImportSource @emotion/react */
 import { Global, css } from '@emotion/react';
-import emotionReset from 'emotion-reset';
 
 const globalStyles = (theme) => css`
-  ${emotionReset}
+  /* Reset CSS 시작 */
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
 
   body {
-    height: 100vh;
+    line-height: 1;
+  }
 
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  blockquote,
+  q {
+    quotes: none;
+  }
+
+  blockquote::before,
+  blockquote::after,
+  q::before,
+  q::after {
+    content: '';
+    content: none;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  /* 폼 요소 초기화 */
+  button,
+  input,
+  select,
+  textarea {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
+
+  /* Reset CSS 끝 */
+
+  /* box-sizing 전체 적용 */
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  /* 버튼 커서 */
+  button {
+    cursor: pointer;
+  }
+
+  /* 글로벌 커스텀 스타일 */
+  body {
+    height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
# 주요 변경사항

## 1. 스타일 초기화 (reset.css 적용)
- emotion의 기본 reset이 부족하여 별도로 `reset.css` 추가
- 브라우저 기본 스타일 제거로 스타일링의 일관성 확보

## 2. 레이아웃 안정화
- **높이 고정**
  - 리스트 데이터에 따라 변하는 레이아웃 문제 해결
  - 고정 높이로 일관된 레이아웃 유지
- **border 수정**
  - 고정된 높이에 맞춰 border 스타일을 조정
  - 디자인 통일성 향상