### PR TITLE
✨ Feat: carousel 기능 구현

### DIFF
--- a/src/assets/icons/LeftButton.svg
+++ b/src/assets/icons/LeftButton.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="42" viewBox="0 0 26 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M25 1L1 21L25 41" stroke="#6E8091"/>
+</svg>

--- a/src/assets/icons/RightButton.svg
+++ b/src/assets/icons/RightButton.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="42" viewBox="0 0 26 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 41L25 21L1 1" stroke="#6E8091"/>
+</svg>

--- a/src/components/Media/MediaSection/Carousel/CarouselButton.jsx
+++ b/src/components/Media/MediaSection/Carousel/CarouselButton.jsx
@@ -1,0 +1,17 @@
+import LeftArrow from '@/assets/icons/LeftButton.svg?react';
+import RightArrow from '@/assets/icons/RightButton.svg?react';
+
+export default function CarouselButton({ position, handler, className }) {
+  const Icon = position === 'prev' ? LeftArrow : RightArrow;
+
+  return (
+    <button
+      onClick={handler}
+      type="button"
+      aria-label={position === 'prev' ? 'Previous slide' : 'Next slide'}
+      className={className}
+    >
+      <Icon />
+    </button>
+  );
+}

--- a/src/components/Media/MediaSection/Carousel/index.jsx
+++ b/src/components/Media/MediaSection/Carousel/index.jsx
@@ -1,17 +1,43 @@
-import LeftArrow from '@/assets/icons/LeftButton.svg?react';
-import RightArrow from '@/assets/icons/RightButton.svg?react';
+import styled from '@emotion/styled';
 
-export default function CarouselButton({ position, handler, className }) {
-  const Icon = position === 'prev' ? LeftArrow : RightArrow;
+import CarouselButton from './CarouselButton';
 
+const CarouselContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled(CarouselButton)`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+`;
+
+const Carousel = ({
+  children,
+  goPrev,
+  goNext,
+  showPrev = true,
+  showNext = true,
+}) => {
   return (
-    <button
-      onClick={handler}
-      type="button"
-      aria-label={position === 'prev' ? 'Previous slide' : 'Next slide'}
-      className={className}
-    >
-      <Icon />
-    </button>
+    <CarouselContainer>
+      {showPrev && <Button position="prev" handler={goPrev} />}
+      {children}
+      {showNext && <Button position="next" handler={goNext} />}
+    </CarouselContainer>
   );
-}
+};
+
+export default Carousel;

--- a/src/components/Media/MediaSection/Carousel/index.jsx
+++ b/src/components/Media/MediaSection/Carousel/index.jsx
@@ -1,0 +1,17 @@
+import LeftArrow from '@/assets/icons/LeftButton.svg?react';
+import RightArrow from '@/assets/icons/RightButton.svg?react';
+
+export default function CarouselButton({ position, handler, className }) {
+  const Icon = position === 'prev' ? LeftArrow : RightArrow;
+
+  return (
+    <button
+      onClick={handler}
+      type="button"
+      aria-label={position === 'prev' ? 'Previous slide' : 'Next slide'}
+      className={className}
+    >
+      <Icon />
+    </button>
+  );
+}

--- a/src/components/Media/MediaSection/Carousel/useCarousel.js
+++ b/src/components/Media/MediaSection/Carousel/useCarousel.js
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 
-export default function useCarousel({ autoPlay = true, totalPage }) {
+export default function useCarousel() {
   const [currentPage, setCurrentPage] = useState(0);
-  const [isAutoPlay, setAutoPlay] = useState(autoPlay);
 
   function goNext() {
     setCurrentPage((prev) => prev + 1);
@@ -16,20 +15,10 @@ export default function useCarousel({ autoPlay = true, totalPage }) {
     setCurrentPage(page);
   }
 
-  function startAutoPlay() {
-    setAutoPlay(true);
-  }
-
-  function stopAutoPlay() {
-    setAutoPlay(false);
-  }
-
   return {
     currentPage,
     goNext,
     goPrev,
     reset,
-    startAutoPlay,
-    stopAutoPlay,
   };
 }

--- a/src/components/Media/MediaSection/Carousel/useCarousel.js
+++ b/src/components/Media/MediaSection/Carousel/useCarousel.js
@@ -12,8 +12,8 @@ export default function useCarousel({ autoPlay = true, totalPage }) {
     setCurrentPage((prev) => prev - 1);
   }
 
-  function reset() {
-    setCurrentPage(0);
+  function reset(page = 0) {
+    setCurrentPage(page);
   }
 
   function startAutoPlay() {

--- a/src/components/Media/MediaSection/Carousel/useCarousel.js
+++ b/src/components/Media/MediaSection/Carousel/useCarousel.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export default function useCarousel({ autoPlay = true, totalPage }) {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [isAutoPlay, setAutoPlay] = useState(autoPlay);
+
+  function goNext() {
+    setCurrentPage((prev) => prev + 1);
+  }
+
+  function goPrev() {
+    setCurrentPage((prev) => prev - 1);
+  }
+
+  function reset() {
+    setCurrentPage(0);
+  }
+
+  function startAutoPlay() {
+    setAutoPlay(true);
+  }
+
+  function stopAutoPlay() {
+    setAutoPlay(false);
+  }
+
+  return {
+    currentPage,
+    goNext,
+    goPrev,
+    reset,
+    startAutoPlay,
+    stopAutoPlay,
+  };
+}

--- a/src/components/Media/MediaSection/GridView/index.jsx
+++ b/src/components/Media/MediaSection/GridView/index.jsx
@@ -1,33 +1,8 @@
-import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
 import GridView from './GridView';
-import CarouselButton from '../Carousel';
+import Carousel from '../Carousel';
 import useCarousel from '../Carousel/useCarousel';
-
-const MediaContainer = styled.div`
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const Button = styled(CarouselButton)`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-
-  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
-
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-`;
 
 const GridViewContainer = ({ data: pressList }) => {
   const [totalPage, setTotalPage] = useState(0);
@@ -48,11 +23,14 @@ const GridViewContainer = ({ data: pressList }) => {
   }, [pressList]);
 
   return (
-    <MediaContainer>
-      {currentPage > 0 && <Button position="prev" handler={goPrev} />}
+    <Carousel
+      goNext={goNext}
+      goPrev={goPrev}
+      showPrev={currentPage > 0}
+      showNext={currentPage < totalPage}
+    >
       <GridView data={selectedPressData} />
-      {currentPage < totalPage && <Button position="next" handler={goNext} />}
-    </MediaContainer>
+    </Carousel>
   );
 };
 

--- a/src/components/Media/MediaSection/GridView/index.jsx
+++ b/src/components/Media/MediaSection/GridView/index.jsx
@@ -1,8 +1,38 @@
-import { useEffect } from 'react';
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 
 import GridView from './GridView';
+import CarouselButton from '../Carousel';
+import useCarousel from '../Carousel/useCarousel';
 
-const GridViewContainer = ({ data: pressList, setTotalPage, currentPage }) => {
+const MediaContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled(CarouselButton)`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
+
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+`;
+
+const GridViewContainer = ({ data: pressList }) => {
+  const [totalPage, setTotalPage] = useState(0);
+  const { currentPage, goNext, goPrev } = useCarousel({ totalPage });
+
   const ITEMS_PER_PAGE = 24;
   const MAX_PAGE = 4;
 
@@ -17,7 +47,13 @@ const GridViewContainer = ({ data: pressList, setTotalPage, currentPage }) => {
     setTotalPage(limitedPageCount - 1);
   }, [pressList]);
 
-  return <GridView data={selectedPressData} />;
+  return (
+    <MediaContainer>
+      {currentPage > 0 && <Button position="prev" handler={goPrev} />}
+      <GridView data={selectedPressData} />
+      {currentPage < totalPage && <Button position="next" handler={goNext} />}
+    </MediaContainer>
+  );
 };
 
 export default GridViewContainer;

--- a/src/components/Media/MediaSection/GridView/index.jsx
+++ b/src/components/Media/MediaSection/GridView/index.jsx
@@ -31,7 +31,7 @@ const Button = styled(CarouselButton)`
 
 const GridViewContainer = ({ data: pressList }) => {
   const [totalPage, setTotalPage] = useState(0);
-  const { currentPage, goNext, goPrev } = useCarousel({ totalPage });
+  const { currentPage, goNext, goPrev } = useCarousel();
 
   const ITEMS_PER_PAGE = 24;
   const MAX_PAGE = 4;

--- a/src/components/Media/MediaSection/GridView/index.jsx
+++ b/src/components/Media/MediaSection/GridView/index.jsx
@@ -1,16 +1,21 @@
-import { useState } from 'react';
+import { useEffect } from 'react';
 
 import GridView from './GridView';
 
-const GridViewContainer = ({ data: pressList }) => {
-  const [currentPage, setCurrentPage] = useState(1);
-
+const GridViewContainer = ({ data: pressList, setTotalPage, currentPage }) => {
   const ITEMS_PER_PAGE = 24;
+  const MAX_PAGE = 4;
 
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const startIndex = currentPage * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;
 
   const selectedPressData = pressList.slice(startIndex, endIndex);
+
+  useEffect(() => {
+    const totalPageCount = Math.ceil(pressList.length / ITEMS_PER_PAGE);
+    const limitedPageCount = Math.min(totalPageCount, MAX_PAGE);
+    setTotalPage(limitedPageCount - 1);
+  }, [pressList]);
 
   return <GridView data={selectedPressData} />;
 };

--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -44,29 +44,29 @@ const EditedByPress = styled.div`
 `;
 
 const ListView = ({
-  data: pressList,
-  category,
-  setCategory,
+  data: pressData,
+  currentCategory,
+  setCurrentCategory,
   currentPage,
   totalPressCount,
   reset,
 }) => {
-  const { logoLight, regDate, materials, name } = pressList;
+  const { logoLight, regDate, materials, name } = pressData;
 
   const mainNews = materials[0];
   const subNewsList = materials.slice(1);
 
   function handleCategory(key) {
     reset();
-    setCategory(key);
+    setCurrentCategory(key);
   }
 
   return (
     <Container>
       <FieldTab
-        category={category}
+        currentCategory={currentCategory}
         handleCategory={handleCategory}
-        pressLength={totalPressCount}
+        totalPressCount={totalPressCount}
         currentPressIndex={currentPage}
       />
       <PressNews>

--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -47,8 +47,7 @@ const ListView = ({
   data: pressList,
   category,
   setCategory,
-  currentPressIndex,
-  setCurrentPressIndex,
+  currentPage,
   totalPressCount,
 }) => {
   const { logoLight, regDate, materials, name } = pressList;
@@ -62,7 +61,7 @@ const ListView = ({
         category={category}
         setCategory={setCategory}
         pressLength={totalPressCount}
-        currentPressIndex={currentPressIndex}
+        currentPressIndex={currentPage}
       />
       <PressNews>
         <PressInfo logoUrl={logoLight} editedTime={regDate} />

--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -49,17 +49,23 @@ const ListView = ({
   setCategory,
   currentPage,
   totalPressCount,
+  reset,
 }) => {
   const { logoLight, regDate, materials, name } = pressList;
 
   const mainNews = materials[0];
   const subNewsList = materials.slice(1);
 
+  function handleCategory(key) {
+    reset();
+    setCategory(key);
+  }
+
   return (
     <Container>
       <FieldTab
         category={category}
-        setCategory={setCategory}
+        handleCategory={handleCategory}
         pressLength={totalPressCount}
         currentPressIndex={currentPage}
       />

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -44,12 +44,12 @@ function TabButton({ label, isActive, onClick, count }) {
 }
 
 export default function FieldTab({
-  category,
+  currentCategory,
   handleCategory,
-  pressLength,
+  totalPressCount,
   currentPressIndex,
 }) {
-  const countLabel = `${currentPressIndex + 1}/${pressLength}`;
+  const countLabel = `${currentPressIndex + 1}/${totalPressCount}`;
 
   return (
     <StyledFieldTab>
@@ -58,7 +58,7 @@ export default function FieldTab({
           key={key}
           label={label}
           onClick={() => handleCategory(key)}
-          isActive={category === key}
+          isActive={currentCategory === key}
           count={countLabel}
         />
       ))}

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -57,7 +57,7 @@ export default function FieldTab({
     { id: 7, label: '지역', key: 'local' },
   ];
 
-  const countLabel = `${currentPressIndex}/${pressLength}`;
+  const countLabel = `${currentPressIndex + 1}/${pressLength}`;
 
   return (
     <StyledFieldTab>

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
 
+import { fieldMap } from '@/utils/constants/constants';
+
 const StyledFieldTab = styled.div`
   display: flex;
   border: 1px solid ${({ theme }) => theme.colors.border.default};
@@ -47,16 +49,6 @@ export default function FieldTab({
   pressLength,
   currentPressIndex,
 }) {
-  const fieldMap = [
-    { id: 1, label: '종합/경제', key: 'generalEconomy' },
-    { id: 2, label: '방송/통신', key: 'broadcastMedia' },
-    { id: 3, label: 'IT', key: 'it' },
-    { id: 4, label: '영자지', key: 'english' },
-    { id: 5, label: '스포츠/연예', key: 'sportsEntertainment' },
-    { id: 6, label: '매거진/전문지', key: 'magazine' },
-    { id: 7, label: '지역', key: 'local' },
-  ];
-
   const countLabel = `${currentPressIndex + 1}/${pressLength}`;
 
   return (

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -43,7 +43,7 @@ function TabButton({ label, isActive, onClick, count }) {
 
 export default function FieldTab({
   category,
-  setCategory,
+  handleCategory,
   pressLength,
   currentPressIndex,
 }) {
@@ -65,7 +65,7 @@ export default function FieldTab({
         <TabButton
           key={key}
           label={label}
-          onClick={() => setCategory(key)}
+          onClick={() => handleCategory(key)}
           isActive={category === key}
           count={countLabel}
         />

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -1,20 +1,32 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import ListView from './ListView';
 
-const ListViewContainer = ({ data: pressList }) => {
+const ListViewContainer = ({
+  data: pressList,
+  setTotalPage,
+  currentPage,
+  reset,
+}) => {
   const [category, setCategory] = useState('generalEconomy');
-  const [currentPressIndex, setCurrentPressIndex] = useState(1);
 
   const selectedPressList = pressList[category];
-  const selectedPressData = pressList[category][currentPressIndex];
+  const selectedPressData = pressList[category][currentPage];
+
+  useEffect(() => {
+    setTotalPage(selectedPressList.length - 1);
+  });
+
+  useEffect(() => {
+    console.log('리셋됨');
+    reset();
+  }, [category]);
 
   return (
     <ListView
       category={category}
       setCategory={setCategory}
-      currentPressIndex={currentPressIndex}
-      setCurrentPressIndex={setCurrentPressIndex}
+      currentPage={currentPage}
       data={selectedPressData}
       totalPressCount={selectedPressList.length}
     />

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -6,32 +6,35 @@ import ListView from './ListView';
 import Carousel from '../Carousel';
 import useCarousel from '../Carousel/useCarousel';
 
-const ListViewContainer = ({ data: pressList }) => {
+const ListViewContainer = ({ data }) => {
   const [totalPage, setTotalPage] = useState(0);
   const { currentPage, goNext, goPrev, reset } = useCarousel();
-  const [category, setCategory] = useState('generalEconomy');
+  const [currentCategory, setCurrentCategory] = useState('generalEconomy');
 
-  const selectedPressList = pressList[category];
-  const selectedPressData = selectedPressList[currentPage];
+  const pressList = data[currentCategory];
+  const selectedPressData = pressList[currentPage];
 
-  const getCategoryIndex = useCallback(
+  const getCurrentCategoryIndex = useCallback(
     (direction) => {
-      const currentIndex = fieldMap.findIndex((item) => item.key === category);
+      const currentIndex = fieldMap.findIndex(
+        (item) => item.key === currentCategory
+      );
       const nextIndex =
         (currentIndex + direction + fieldMap.length) % fieldMap.length;
       return nextIndex;
     },
-    [category]
+    [currentCategory]
   );
 
   function goToPrevPage() {
     if (currentPage === 0) {
-      const prevIndex = getCategoryIndex(-1);
-      const prevCategory = fieldMap[prevIndex].key;
+      const prevIndex = getCurrentCategoryIndex(-1);
+      const previousCategory = fieldMap[prevIndex].key;
 
-      // 카테고리 변경 전에 이전 카테고리의 총 페이지 수를 계산 : category 상태는 이전값.
-      const prevCategoryTotalPage = pressList[prevCategory].length - 1;
-      setCategory(prevCategory);
+      // 카테고리 변경 전에 이전 카테고리의 총 페이지 수를 계산 : currentCategory 상태는 이전값.
+      const prevCategoryTotalPage = data[previousCategory].length - 1;
+
+      setCurrentCategory(previousCategory);
       reset(prevCategoryTotalPage);
     } else {
       goPrev();
@@ -40,10 +43,10 @@ const ListViewContainer = ({ data: pressList }) => {
 
   function goToNextPage() {
     if (currentPage === totalPage) {
-      const nextIndex = getCategoryIndex(1);
+      const nextIndex = getCurrentCategoryIndex(1);
       const nextCategory = fieldMap[nextIndex].key;
 
-      setCategory(nextCategory);
+      setCurrentCategory(nextCategory);
       reset();
     } else {
       goNext();
@@ -51,8 +54,8 @@ const ListViewContainer = ({ data: pressList }) => {
   }
 
   useEffect(() => {
-    setTotalPage(selectedPressList.length - 1);
-  }, [category]);
+    setTotalPage(pressList.length - 1);
+  }, [currentCategory]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -60,16 +63,16 @@ const ListViewContainer = ({ data: pressList }) => {
     }, 20000);
 
     return () => clearInterval(interval);
-  }, [currentPage, totalPage, category]);
+  }, [currentPage, totalPage, currentCategory]);
 
   return (
     <Carousel goPrev={goToPrevPage} goNext={goToNextPage}>
       <ListView
-        category={category}
-        setCategory={setCategory}
+        currentCategory={currentCategory}
+        setCurrentCategory={setCurrentCategory}
         currentPage={currentPage}
         data={selectedPressData}
-        totalPressCount={selectedPressList.length}
+        totalPressCount={pressList.length}
         reset={reset}
       />
     </Carousel>

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -58,7 +58,7 @@ const ListViewContainer = ({ data: pressList }) => {
   function goToNextPage() {
     if (currentPage === totalPage) {
       const currentIndex = fieldMap.findIndex((item) => item.key === category);
-      const nextIndex = ((currentIndex + 1) % fieldMap.length) - 1;
+      const nextIndex = (currentIndex + 1) % fieldMap.length;
       setCategory(fieldMap[nextIndex].key);
       reset();
     } else {
@@ -68,7 +68,15 @@ const ListViewContainer = ({ data: pressList }) => {
 
   useEffect(() => {
     setTotalPage(selectedPressList.length - 1);
-  }, [category, selectedPressList, setTotalPage]);
+  }, [category, selectedPressList]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      goToNextPage();
+    }, 20000);
+
+    return () => clearInterval(interval);
+  }, [currentPage, totalPage, category]);
 
   return (
     <MediaContainer>

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
+import { fieldMap } from '@/utils/constants/constants';
+
 import CarouselButton from '../Carousel';
 import ListView from './ListView';
 import useCarousel from '../Carousel/useCarousel';
@@ -37,13 +39,40 @@ const ListViewContainer = ({ data: pressList }) => {
   const selectedPressList = pressList[category];
   const selectedPressData = selectedPressList[currentPage];
 
+  function goToPrevPage() {
+    if (currentPage === 0) {
+      const currentIndex = fieldMap.findIndex((item) => item.key === category);
+      const prevIndex = (currentIndex - 1 + fieldMap.length) % fieldMap.length;
+      const prevCategory = fieldMap[prevIndex].key;
+
+      // 카테고리 변경 전에 이전 카테고리의 총 페이지 수를 계산 : category 상태는 이전값.
+      const prevCategoryTotalPage = pressList[prevCategory].length - 1;
+
+      setCategory(prevCategory);
+      reset(prevCategoryTotalPage);
+    } else {
+      goPrev();
+    }
+  }
+
+  function goToNextPage() {
+    if (currentPage === totalPage) {
+      const currentIndex = fieldMap.findIndex((item) => item.key === category);
+      const nextIndex = ((currentIndex + 1) % fieldMap.length) - 1;
+      setCategory(fieldMap[nextIndex].key);
+      reset();
+    } else {
+      goNext();
+    }
+  }
+
   useEffect(() => {
     setTotalPage(selectedPressList.length - 1);
   }, [category, selectedPressList, setTotalPage]);
 
   return (
     <MediaContainer>
-      <Button position="prev" handler={goPrev} />
+      <Button position="prev" handler={goToPrevPage} />
       <ListView
         category={category}
         setCategory={setCategory}
@@ -52,7 +81,7 @@ const ListViewContainer = ({ data: pressList }) => {
         totalPressCount={selectedPressList.length}
         reset={reset}
       />
-      <Button position="next" handler={goNext} />
+      <Button position="next" handler={goToNextPage} />
     </MediaContainer>
   );
 };

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -1,35 +1,10 @@
-import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
 import { fieldMap } from '@/utils/constants/constants';
 
-import CarouselButton from '../Carousel';
 import ListView from './ListView';
+import Carousel from '../Carousel';
 import useCarousel from '../Carousel/useCarousel';
-
-const MediaContainer = styled.div`
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const Button = styled(CarouselButton)`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-
-  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
-
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-`;
 
 const ListViewContainer = ({ data: pressList }) => {
   const [totalPage, setTotalPage] = useState(0);
@@ -79,8 +54,7 @@ const ListViewContainer = ({ data: pressList }) => {
   }, [currentPage, totalPage, category]);
 
   return (
-    <MediaContainer>
-      <Button position="prev" handler={goToPrevPage} />
+    <Carousel goPrev={goToPrevPage} goNext={goToNextPage}>
       <ListView
         category={category}
         setCategory={setCategory}
@@ -89,8 +63,7 @@ const ListViewContainer = ({ data: pressList }) => {
         totalPressCount={selectedPressList.length}
         reset={reset}
       />
-      <Button position="next" handler={goToNextPage} />
-    </MediaContainer>
+    </Carousel>
   );
 };
 

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -11,16 +11,11 @@ const ListViewContainer = ({
   const [category, setCategory] = useState('generalEconomy');
 
   const selectedPressList = pressList[category];
-  const selectedPressData = pressList[category][currentPage];
+  const selectedPressData = selectedPressList[currentPage];
 
   useEffect(() => {
     setTotalPage(selectedPressList.length - 1);
-  });
-
-  useEffect(() => {
-    console.log('리셋됨');
-    reset();
-  }, [category]);
+  }, [category, selectedPressList, setTotalPage]);
 
   return (
     <ListView
@@ -29,6 +24,7 @@ const ListViewContainer = ({
       currentPage={currentPage}
       data={selectedPressData}
       totalPressCount={selectedPressList.length}
+      reset={reset}
     />
   );
 };

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -1,13 +1,37 @@
+import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
+import CarouselButton from '../Carousel';
 import ListView from './ListView';
+import useCarousel from '../Carousel/useCarousel';
 
-const ListViewContainer = ({
-  data: pressList,
-  setTotalPage,
-  currentPage,
-  reset,
-}) => {
+const MediaContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled(CarouselButton)`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
+
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+`;
+
+const ListViewContainer = ({ data: pressList }) => {
+  const [totalPage, setTotalPage] = useState(0);
+  const { currentPage, goNext, goPrev, reset } = useCarousel({ totalPage });
   const [category, setCategory] = useState('generalEconomy');
 
   const selectedPressList = pressList[category];
@@ -18,14 +42,18 @@ const ListViewContainer = ({
   }, [category, selectedPressList, setTotalPage]);
 
   return (
-    <ListView
-      category={category}
-      setCategory={setCategory}
-      currentPage={currentPage}
-      data={selectedPressData}
-      totalPressCount={selectedPressList.length}
-      reset={reset}
-    />
+    <MediaContainer>
+      <Button position="prev" handler={goPrev} />
+      <ListView
+        category={category}
+        setCategory={setCategory}
+        currentPage={currentPage}
+        data={selectedPressData}
+        totalPressCount={selectedPressList.length}
+        reset={reset}
+      />
+      <Button position="next" handler={goNext} />
+    </MediaContainer>
   );
 };
 

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -33,7 +33,7 @@ const Button = styled(CarouselButton)`
 
 const ListViewContainer = ({ data: pressList }) => {
   const [totalPage, setTotalPage] = useState(0);
-  const { currentPage, goNext, goPrev, reset } = useCarousel({ totalPage });
+  const { currentPage, goNext, goPrev, reset } = useCarousel();
   const [category, setCategory] = useState('generalEconomy');
 
   const selectedPressList = pressList[category];

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { fieldMap } from '@/utils/constants/constants';
 
@@ -14,15 +14,23 @@ const ListViewContainer = ({ data: pressList }) => {
   const selectedPressList = pressList[category];
   const selectedPressData = selectedPressList[currentPage];
 
+  const getCategoryIndex = useCallback(
+    (direction) => {
+      const currentIndex = fieldMap.findIndex((item) => item.key === category);
+      const nextIndex =
+        (currentIndex + direction + fieldMap.length) % fieldMap.length;
+      return nextIndex;
+    },
+    [category]
+  );
+
   function goToPrevPage() {
     if (currentPage === 0) {
-      const currentIndex = fieldMap.findIndex((item) => item.key === category);
-      const prevIndex = (currentIndex - 1 + fieldMap.length) % fieldMap.length;
+      const prevIndex = getCategoryIndex(-1);
       const prevCategory = fieldMap[prevIndex].key;
 
       // 카테고리 변경 전에 이전 카테고리의 총 페이지 수를 계산 : category 상태는 이전값.
       const prevCategoryTotalPage = pressList[prevCategory].length - 1;
-
       setCategory(prevCategory);
       reset(prevCategoryTotalPage);
     } else {
@@ -32,9 +40,10 @@ const ListViewContainer = ({ data: pressList }) => {
 
   function goToNextPage() {
     if (currentPage === totalPage) {
-      const currentIndex = fieldMap.findIndex((item) => item.key === category);
-      const nextIndex = (currentIndex + 1) % fieldMap.length;
-      setCategory(fieldMap[nextIndex].key);
+      const nextIndex = getCategoryIndex(1);
+      const nextCategory = fieldMap[nextIndex].key;
+
+      setCategory(nextCategory);
       reset();
     } else {
       goNext();
@@ -43,7 +52,7 @@ const ListViewContainer = ({ data: pressList }) => {
 
   useEffect(() => {
     setTotalPage(selectedPressList.length - 1);
-  }, [category, selectedPressList]);
+  }, [category]);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/src/components/Media/MediaSection/index.jsx
+++ b/src/components/Media/MediaSection/index.jsx
@@ -1,39 +1,7 @@
-import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
-
-import CarouselButton from './Carousel';
-import useCarousel from './Carousel/useCarousel';
 import GridView from './GridView';
 import ListView from './ListView';
 
-const MediaContainer = styled.div`
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const Button = styled(CarouselButton)`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-
-  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
-
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-`;
-
 const MediaSection = ({ viewType, data }) => {
-  const [totalPage, setTotalPage] = useState(0);
-  const { currentPage, goNext, goPrev, reset } = useCarousel({ totalPage });
-
   function getViewComponent(type) {
     const map = {
       list: ListView,
@@ -44,22 +12,7 @@ const MediaSection = ({ viewType, data }) => {
 
   const ViewComponet = getViewComponent(viewType);
 
-  useEffect(() => {
-    reset();
-  }, [viewType]);
-
-  return (
-    <MediaContainer>
-      {currentPage > 0 && <Button position="prev" handler={goPrev} />}
-      <ViewComponet
-        data={data}
-        setTotalPage={setTotalPage}
-        currentPage={currentPage}
-        reset={reset}
-      />
-      {currentPage < totalPage && <Button position="next" handler={goNext} />}
-    </MediaContainer>
-  );
+  return <ViewComponet data={data} />;
 };
 
 export default MediaSection;

--- a/src/components/Media/MediaSection/index.jsx
+++ b/src/components/Media/MediaSection/index.jsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 
 import CarouselButton from './Carousel';
+import useCarousel from './Carousel/useCarousel';
 import GridView from './GridView';
 import ListView from './ListView';
 
@@ -29,13 +31,8 @@ const Button = styled(CarouselButton)`
 `;
 
 const MediaSection = ({ viewType, data }) => {
-  function handlePrev() {
-    console.log('왼쪽 클릭');
-  }
-
-  function handleNext() {
-    console.log('오른쪽 클릭');
-  }
+  const [totalPage, setTotalPage] = useState(0);
+  const { currentPage, goNext, goPrev, reset } = useCarousel({ totalPage });
 
   function getViewComponent(type) {
     const map = {
@@ -47,11 +44,20 @@ const MediaSection = ({ viewType, data }) => {
 
   const ViewComponet = getViewComponent(viewType);
 
+  useEffect(() => {
+    reset();
+  }, [viewType]);
+
   return (
     <MediaContainer>
-      <Button position="prev" handler={handlePrev} />
-      <ViewComponet data={data} />
-      <Button position="next" handler={handleNext} />
+      {currentPage > 0 && <Button position="prev" handler={goPrev} />}
+      <ViewComponet
+        data={data}
+        setTotalPage={setTotalPage}
+        currentPage={currentPage}
+        reset={reset}
+      />
+      {currentPage < totalPage && <Button position="next" handler={goNext} />}
     </MediaContainer>
   );
 };

--- a/src/components/Media/MediaSection/index.jsx
+++ b/src/components/Media/MediaSection/index.jsx
@@ -1,7 +1,42 @@
+import styled from '@emotion/styled';
+
+import CarouselButton from './Carousel';
 import GridView from './GridView';
 import ListView from './ListView';
 
+const MediaContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled(CarouselButton)`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  ${({ position }) => (position === 'prev' ? 'left: -80px;' : 'right: -80px;')}
+
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+`;
+
 const MediaSection = ({ viewType, data }) => {
+  function handlePrev() {
+    console.log('왼쪽 클릭');
+  }
+
+  function handleNext() {
+    console.log('오른쪽 클릭');
+  }
+
   function getViewComponent(type) {
     const map = {
       list: ListView,
@@ -12,7 +47,13 @@ const MediaSection = ({ viewType, data }) => {
 
   const ViewComponet = getViewComponent(viewType);
 
-  return <ViewComponet data={data} />;
+  return (
+    <MediaContainer>
+      <Button position="prev" handler={handlePrev} />
+      <ViewComponet data={data} />
+      <Button position="next" handler={handleNext} />
+    </MediaContainer>
+  );
 };
 
 export default MediaSection;

--- a/src/utils/constants/constants.js
+++ b/src/utils/constants/constants.js
@@ -1,0 +1,9 @@
+export const fieldMap = [
+  { id: 1, label: '종합/경제', key: 'generalEconomy' },
+  { id: 2, label: '방송/통신', key: 'broadcastMedia' },
+  { id: 3, label: 'IT', key: 'it' },
+  { id: 4, label: '영자지', key: 'english' },
+  { id: 5, label: '스포츠/연예', key: 'sportsEntertainment' },
+  { id: 6, label: '매거진/전문지', key: 'magazine' },
+  { id: 7, label: '지역', key: 'local' },
+];


### PR DESCRIPTION
## 주요 구현 사항
- List/Grid View에서 사용하는 캐러셀 기능 구현
  - 캐러셀 버튼 컴포넌트와, 컨테이너 컴포넌트를 만들어서 각 뷰 컴포넌트에서 재사용하게 함.
  - useCarousel 커스텀 훅을 만들어서 캐러셀 로직을 재사용함.
  - 그리드에서는 수동 캐러셀 기능만 작동하게 하며, 이동할 페이지가 없을 경우 버튼을 감춤
  - 리스트에서는 수동/자동 캐러셀 기능이 작동하며, 무한 캐러셀로 작동함.

---

## 주요 문제와 해결

### 1. **캐러셀 버튼 로직을 어떻게 공통으로 쓸까?**

#### 🧐 **고민의 배경**

- **리스트**와 **그리드**에서 **공통적인 캐러셀 버튼**을 사용하려고 했으나, **동작의 차이**로 인해 문제가 발생했습니다.
- **리스트**는 **무한 캐러셀과 자동 페이지 전환**이 필요했고, **그리드**는 **수동 페이지 전환**만 필요했습니다.
- **목표**는: **리스트**와 **그리드**의 특성을 고려하면서도 공통 로직을 효율적으로 처리할 수 있는 방법을 찾는 것이었습니다.

#### **고려한 방식**

1. **`useCarousel`에서 로직 분기 처리**  
   - `viewType`을 기반으로 **리스트**와 **그리드**의 **동작을 분기**하는 방법을 고려했습니다.  
   - **리스트**와 **그리드**에서 동작이 다르므로, **`useCarousel` 훅** 내에서 **조건에 따라** 자동/수동 전환 로직을 처리하려 했습니다.

2. **`useCarousel`은 공통 로직만 두고, 외부에서 추가 로직 정의**  
   - **공통 로직**은 **`useCarousel`**에 두고, 각 **리스트**와 **그리드**에서 필요한 추가적인 **로직**을 **각각의 뷰에서 처리**하도록 하여 **유지보수성**을 높이기로 결정했습니다.  
   - **핸들러(`goNext`, `goPrev`)**는 **리스트/그리드**에서 각각 정의하고, **`useCarousel`**에서 공통된 기능을 관리하는 방식을 택했습니다.

#### ✅ **최종 해결**

- **`useCarousel`**은 **공통 로직만 처리**하고, 각 뷰 컴포넌트에서 필요한 **추가 로직을 정의**하는 방식으로 처리하기로 했습니다.
- **리스트**와 **그리드에서 필요한 로직**을 각 컴포넌트에서 독립적으로 관리하여, **동작이 다르더라도 공통 훅을 활용**할 수 있게 됐습니다.
- **`MediaSection`**에서는 공통적으로 **`useCarousel`**을 사용하고, **리스트/그리드에서 필요한 로직만 별도로 처리**하여 **상위 컴포넌트의 역할을 최소화**했습니다.

---

### 2. **각 카테고리의 마지막 페이지일 경우 다음 카테고리로 넘어가게 할까?**

#### 🧐 **고민의 배경**

- **리스트**에서 **각 카테고리의 마지막 페이지**에 도달했을 때, **다음 카테고리로 자동 전환**하는 로직을 구현해야 했습니다.
- **그리드**에서는 **카테고리 전환이 필요 없고**, **리스트**에서만 **카테고리 전환**이 필요했습니다.  
- 이를 **어떻게 처리할지**에 대한 고민이 있었습니다.

#### **고려한 방식**

1. **`useCarousel`에서 카테고리 상태를 내부에서 처리**  
   - **`useCarousel` 훅**에서 **카테고리 상태**를 관리하고, **페이지 이동**과 **카테고리 전환**을 내부에서 처리하는 방법을 고려했습니다.

2. **`useCarousel`에서 기본적인 페이지 상태만 관리하고, 외부에서 `goNext`와 같은 함수로 동작 구현**  
   - **리스트 컴포넌트에서 `goNext`, `goPrev`와 같은 핸들러를 정의**하고, **캐러셀 버튼에 해당 핸들러를 전달**하는 방식으로, **리스트에서 캐러셀 버튼을 클릭했을 때 동작**을 **한눈에 보이게 처리**하려는 방식이 더 직관적이라고 판단했습니다.

#### ✅ **최종 선택**

- **`useCarousel`**은 **공통 로직만 처리**하고, **핸들러(`goNext`, `goPrev`)는 외부에서 정의**하여 **리스트와 그리드에서 동작을 분리**했습니다.
- **핸들러**는 **리스트**에서만 카테고리 전환 로직을 처리하도록 했고, **`useCarousel` 훅은 페이지 상태 관리만 맡게 했습니다.
- **핸들러를 각 뷰에서 정의**하고 **캐러셀 버튼에 전달**하는 방식이 더 **가독성이 높고, 코드 흐름을 쉽게 파악**할 수 있다고 판단했습니다.

#### **선택의 근거**

1. **코드 읽는 흐름을 직관적으로 만들기 위해**  
   - **`useCarousel`**에 **카테고리 전환 로직**을 넣으면, 코드가 **복잡해지고 이해하기 어려운** 구조가 될 것이라고 생각했습니다.  
   - 대신 각 뷰에서 **핸들러를 정의**하고, **각 동작을 한 곳에서 처리**하는 방식이 더 **직관적이고 유지보수에 용이**하다고 판단했습니다.

2. **유지보수성과 확장성**  
   - `useCarousel`은 **단순한 페이지 이동 로직**만 처리하고, **각 뷰에서 필요한 로직**을 **독립적으로 관리**하여 **확장성**이 높고 **재사용성이 뛰어나**지도록 했습니다.

---

### 3. **캐러셀 버튼, `useCarousel`, `totalPage` 상태를 어디에 정의할 것인가?**

#### 🧐 **고민의 배경**

처음에는 **`MediaSection`**에서 **캐러셀 버튼**과 **`useCarousel` 훅**을 모두 정의하고, 그 안에서 **리스트**와 **그리드** 컴포넌트로 **상태를 전달**하는 방식으로 접근했습니다.  
이 방식은 **상위 컴포넌트에서 모든 상태를 관리**할 수 있다는 장점이 있지만, **리스트**와 **그리드**의 **동작이 다르기 때문에** **동작을 분기 처리**하는 데 어려움이 있었습니다.

#### **고민한 점과 고려한 사항**

1. **상위 컴포넌트에서 관리**할 경우
   - **`MediaSection`에서** **`useCarousel`**과 **캐러셀 버튼**을 **모두 정의**하고, **상위 컴포넌트에서 상태 관리**를 하면 **공통적으로 사용**할 수 있다는 장점이 있었습니다.
   - 하지만 **리스트**와 **그리드**에서 **동작이 다르기** 때문에, **상위 컴포넌트에서 분기 처리**해야 하므로 **불필요하게 복잡해질 수 있다는** 단점이 있었습니다.

2. **리스트와 그리드에서 각자 관리**할 경우
   - **`totalPage`**와 **`useCarousel`**을 **각각의 컨테이너에서 관리**하고, **각각의 뷰에서 필요한 로직을 처리**하면 **유지보수성**이 더 좋고, **리스트와 그리드의 요구사항을 명확히 구분**할 수 있습니다.
   - 이 방식은 **상위 컴포넌트에서 역할을 최소화**하고, **각 뷰에서 독립적으로 동작을 관리**하는 방식으로 유리하다고 판단했습니다.

#### ✅ **최종 선택**

- **`useCarousel`과 캐러셀 버튼을** **각각의 리스트/그리드 컨테이너에서 정의**하고, **상위 컴포넌트(`MediaSection`)에서는 뷰만 관리**하도록 결정했습니다.
- **`totalPage` 상태**는 **리스트와 그리드에서** **각각의 필요에 맞게 계산하고 관리**하도록 했습니다. 이렇게 하면 **상위 컴포넌트**에서는 **뷰만 관리**하고, **각 뷰에서 필요한 상태**를 **직접 관리**할 수 있습니다.

---

### 5. **재사용성을 위한 리팩토링: 공통 캐러셀 컨테이너 컴포넌트 추출**

#### 🧐 **고민의 배경**

프로젝트를 진행하면서 `GridViewContainer`와 `ListViewContainer` 컴포넌트는 매우 유사한 구조를 가지고 있었습니다. 두 컴포넌트는 공통적으로 **캐러셀 버튼** (이전, 다음 버튼)과 **컨테이너** (미디어 컨테이너)를 사용하고 있었습니다. 하지만 이들 각각의 컴포넌트에서 버튼과 컨테이너의 로직을 중복해서 작성하고 있었고, 이는 코드 중복을 초래하고 유지보수가 어려운 문제를 발생시켰습니다. 

### **문제점:**
1. **중복 코드**: `GridViewContainer`와 `ListViewContainer`에서 캐러셀 버튼과 미디어 컨테이너 로직을 반복적으로 작성하고 있었기 때문에, 코드의 중복성이 높아지고 수정이 필요할 경우 모든 컴포넌트를 찾아 수정해야 했습니다.
2. **유지보수 어려움**: 각 뷰에서 캐러셀 버튼과 컨테이너 로직을 수정하거나 확장해야 할 경우, 각 컴포넌트에서 동일한 수정 작업을 해야 하므로 실수할 가능성도 높아지고 유지보수가 복잡해졌습니다.
3. **확장성 부족**: 새로운 뷰를 추가할 때마다 동일한 구조를 다시 작성해야 하기 때문에, 코드의 확장성도 제한적이었습니다.

#### ✅ **문제 해결 과정**

이 문제를 해결하기 위해 **공통된 로직을 하나의 컴포넌트로 추출하는 방식**을 택했습니다. `CarouselContainer`라는 컴포넌트를 새로 만들어, **캐러셀 버튼**과 **미디어 컨테이너**의 공통 로직을 한 곳에서 처리하게 했습니다. 이 방식은 여러 뷰 컴포넌트에서 공통적으로 사용될 수 있는 로직을 재사용 가능하도록 만들었습니다.

### **설계 방식:**
1. **`CarouselContainer` 컴포넌트 생성**: `CarouselContainer` 컴포넌트를 새로 만들어, 버튼과 미디어 컨테이너의 공통 로직을 처리하도록 했습니다. 이 컴포넌트는 `children`으로 전달되는 뷰를 감싸는 역할만 하며, **버튼 클릭 시의 이벤트 처리**와 **버튼의 표시 여부**를 제어합니다. 버튼 클릭 시에는 `goPrev`와 `goNext`와 같은 페이지 전환 로직을 처리하는 함수들을 외부에서 전달받습니다.
   
2. **조건부 버튼 렌더링**: `CarouselContainer`는 `showPrev`와 `showNext` props를 사용하여, 각 뷰에서 페이지 전환에 필요한 버튼을 **조건부로 렌더링**합니다. 예를 들어, 그리드 뷰에서는 `prev` 버튼을 표시하고, 리스트 뷰에서는 버튼을 숨기거나 필요한 경우에만 렌더링합니다.

3. **뷰 컴포넌트에서 공통 로직 사용**: 이제 `GridViewContainer`와 `ListViewContainer`는 공통된 `CarouselContainer`를 사용하여 코드 중복을 제거했습니다. 각 뷰는 버튼의 표시 여부와 페이지 전환 로직만 설정하고, 나머지 로직은 `CarouselContainer`에서 처리하게 되었습니다. 이로 인해 각 컴포넌트는 더 깔끔하고 관리하기 쉬워졌습니다.

4. **확장성 고려**: 새로운 뷰 컴포넌트를 추가할 때마다, 해당 뷰는 `CarouselContainer`를 사용하여 버튼과 컨테이너의 공통 로직을 재사용할 수 있게 되었습니다. 이로써 새로운 뷰를 추가하는 데 드는 비용이 크게 줄어들었습니다.
