### PR TITLE
✨ Feat:  progress bar 구현

### DIFF
--- a/src/components/Media/MediaSection/ListView/ListView.jsx
+++ b/src/components/Media/MediaSection/ListView/ListView.jsx
@@ -50,6 +50,7 @@ const ListView = ({
   currentPage,
   totalPressCount,
   reset,
+  progress,
 }) => {
   const { logoLight, regDate, materials, name } = pressData;
 
@@ -68,6 +69,7 @@ const ListView = ({
         handleCategory={handleCategory}
         totalPressCount={totalPressCount}
         currentPressIndex={currentPage}
+        progress={progress}
       />
       <PressNews>
         <PressInfo logoUrl={logoLight} editedTime={regDate} />

--- a/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
+++ b/src/components/Media/MediaSection/ListView/components/FieldTab.jsx
@@ -3,13 +3,17 @@ import styled from '@emotion/styled';
 
 import { fieldMap } from '@/utils/constants/constants';
 
+import ProgressBar from './ProgressBar';
+
 const StyledFieldTab = styled.div`
   display: flex;
+  height: 40px;
   border: 1px solid ${({ theme }) => theme.colors.border.default};
   background-color: ${({ theme }) => theme.colors.surface.alt};
 `;
 
 const StyledButton = styled.button`
+  position: relative;
   width: ${({ isActive }) => (isActive ? '166px' : 'auto')};
   display: flex;
   gap: 8px;
@@ -27,18 +31,25 @@ const StyledButton = styled.button`
 const LabelText = styled.span`
   display: flex;
   flex-grow: ${({ isActive }) => (isActive ? 1 : 0)};
+  z-index: 1;
 `;
 
 const CountText = styled.span`
   ${({ theme }) => theme.typography.b12}
   color: ${({ theme }) => theme.colors.text.whiteWeak};
+  z-index: 1;
 `;
 
-function TabButton({ label, isActive, onClick, count }) {
+function TabButton({ label, isActive, onClick, count, progress }) {
   return (
     <StyledButton isActive={isActive} onClick={onClick}>
       <LabelText isActive={isActive}>{label}</LabelText>
-      {isActive && count != null && <CountText>{count}</CountText>}
+      {isActive && (
+        <>
+          {count && <CountText>{count}</CountText>}
+          <ProgressBar progress={progress} />
+        </>
+      )}
     </StyledButton>
   );
 }
@@ -48,6 +59,7 @@ export default function FieldTab({
   handleCategory,
   totalPressCount,
   currentPressIndex,
+  progress,
 }) {
   const countLabel = `${currentPressIndex + 1}/${totalPressCount}`;
 
@@ -60,6 +72,7 @@ export default function FieldTab({
           onClick={() => handleCategory(key)}
           isActive={currentCategory === key}
           count={countLabel}
+          progress={progress}
         />
       ))}
     </StyledFieldTab>

--- a/src/components/Media/MediaSection/ListView/components/ProgressBar.jsx
+++ b/src/components/Media/MediaSection/ListView/components/ProgressBar.jsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+import styled from '@emotion/styled';
+
+const ProgressWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.surface.brandAlt};
+`;
+
+const ProgressFill = styled.div`
+  width: ${({ progress }) => `${progress}%`};
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.surface.brandDefault};
+  transition: width 0.1s ease-in-out;
+`;
+
+function ProgressBar({ progress }) {
+  return (
+    <ProgressWrapper>
+      <ProgressFill progress={progress} />
+    </ProgressWrapper>
+  );
+}
+
+export default ProgressBar;

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -6,6 +6,8 @@ import ListView from './ListView';
 import Carousel from '../Carousel';
 import useCarousel from '../Carousel/useCarousel';
 
+const DURATION = 20000; // 20초
+
 const ListViewContainer = ({ data }) => {
   const [totalPage, setTotalPage] = useState(0);
   const { currentPage, goNext, goPrev, reset } = useCarousel();
@@ -66,7 +68,7 @@ const ListViewContainer = ({ data }) => {
     const pageChangeInterval = setInterval(() => {
       console.log('실행됨');
       goToNextPage();
-    }, 20000);
+    }, DURATION);
 
     // 프로그레스바 업데이트
     const progressInterval = setInterval(() => {
@@ -75,7 +77,7 @@ const ListViewContainer = ({ data }) => {
           clearInterval(progressInterval);
           return 100;
         }
-        return prev + 0.5; // 진행률
+        return prev + 100 / (DURATION / 100);
       });
     }, 100); // 100ms마다 진행률 업데이트
 

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -59,29 +59,31 @@ const ListViewContainer = ({ data }) => {
   }, [currentCategory]);
 
   useEffect(() => {
+    // 초기화: 프로그레스바 초기화
+    setProgress(0);
+
+    // 20초마다 페이지 변경
     const pageChangeInterval = setInterval(() => {
       console.log('실행됨');
       goToNextPage();
-    }, 20000); // 20초마다 페이지 변경
+    }, 20000);
 
-    return () => clearInterval(pageChangeInterval);
-  }, [currentPage, totalPage, currentCategory]);
-
-  useEffect(() => {
-    setProgress(0);
-
-    const interval = setInterval(() => {
+    // 프로그레스바 업데이트
+    const progressInterval = setInterval(() => {
       setProgress((prev) => {
         if (prev >= 100) {
-          clearInterval(interval); // 100%에 도달하면 interval을 종료합니다.
+          clearInterval(progressInterval);
           return 100;
         }
-        return prev + 0.5;
+        return prev + 0.5; // 진행률
       });
-    }, 100);
+    }, 100); // 100ms마다 진행률 업데이트
 
-    return () => clearInterval(interval);
-  }, [currentPage]);
+    return () => {
+      clearInterval(pageChangeInterval);
+      clearInterval(progressInterval);
+    };
+  }, [currentPage, totalPage, currentCategory]);
 
   return (
     <Carousel goPrev={goToPrevPage} goNext={goToNextPage}>

--- a/src/components/Media/MediaSection/ListView/index.jsx
+++ b/src/components/Media/MediaSection/ListView/index.jsx
@@ -10,6 +10,7 @@ const ListViewContainer = ({ data }) => {
   const [totalPage, setTotalPage] = useState(0);
   const { currentPage, goNext, goPrev, reset } = useCarousel();
   const [currentCategory, setCurrentCategory] = useState('generalEconomy');
+  const [progress, setProgress] = useState(0);
 
   const pressList = data[currentCategory];
   const selectedPressData = pressList[currentPage];
@@ -58,12 +59,29 @@ const ListViewContainer = ({ data }) => {
   }, [currentCategory]);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const pageChangeInterval = setInterval(() => {
+      console.log('실행됨');
       goToNextPage();
-    }, 20000);
+    }, 20000); // 20초마다 페이지 변경
+
+    return () => clearInterval(pageChangeInterval);
+  }, [currentPage, totalPage, currentCategory]);
+
+  useEffect(() => {
+    setProgress(0);
+
+    const interval = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          clearInterval(interval); // 100%에 도달하면 interval을 종료합니다.
+          return 100;
+        }
+        return prev + 0.5;
+      });
+    }, 100);
 
     return () => clearInterval(interval);
-  }, [currentPage, totalPage, currentCategory]);
+  }, [currentPage]);
 
   return (
     <Carousel goPrev={goToPrevPage} goNext={goToNextPage}>
@@ -74,6 +92,7 @@ const ListViewContainer = ({ data }) => {
         data={selectedPressData}
         totalPressCount={pressList.length}
         reset={reset}
+        progress={progress}
       />
     </Carousel>
   );


### PR DESCRIPTION
## 주요 구현 사항

### ✨Feat
#### **Progress Bar 구현**
- 프로그레스바 컴포넌트를 새로 생성하여, `TabButton`의 하위 레이어에 배치했습니다.
- `TabButton`이 활성화되었을 때만 프로그레스바가 나타나도록 했습니다.

---

## 주요 문제 해결

### 문제 0: **프로그레스바 관련 로직을 상위에 둘 것인가, 내부에 둘 것인가?**

#### **🤔 고민의 배경**
프로그레스바를 구현하는 과정에서 **로직을 어디에 배치할지**에 대한 고민이 있었습니다. `ProgressBar`는 **진행 상태(progress)**에 따라 **UI를 업데이트**하는 컴포넌트입니다. 하지만 이 컴포넌트가 **상태를 관리하고 애니메이션 로직을 처리**할지, 아니면 **상위 컴포넌트에서 상태와 로직을 처리하고** `ProgressBar`는 **UI만 담당**할지에 대한 결정이 필요했습니다. 고민의 핵심은 **책임의 분리**와 **구성의 단순화**였습니다. 

#### **🤔 고려한 방식 두 가지**

##### **1. 프로그레스바 로직을 내부에 두는 방식**
- `ProgressBar` 내부에서 진행률을 계산하고 애니메이션을 처리하는 방식입니다.
- UI와 로직이 **`ProgressBar` 안에 모두 포함**됩니다.

###### **장점**
- **단순화**: 코드가 간결하고 직관적입니다.
- **캡슐화**: `ProgressBar`가 **UI와 로직을 모두 처리**하여 다른 컴포넌트에서 쉽게 사용할 수 있습니다.
- **빠른 구현**: 복잡한 상태 관리 없이 UI와 애니메이션을 **빠르게 구현**할 수 있습니다.

###### **단점**
- **유연성 부족**: 로직을 확장하거나 변경할 때 복잡해질 수 있습니다.
- **책임 복잡**: UI와 로직이 결합되어 컴포넌트가 커지거나 복잡해질 수 있습니다.
- **상위 컴포넌트와의 의존성**: 상위에서 상태 제어가 어려워집니다.

##### **2. 프로그레스바 로직을 외부로 빼는 방식**
- `ProgressBar`는 UI만 담당하고, 상위 컴포넌트에서 상태 관리와 애니메이션 로직을 처리하는 방식입니다.

###### **장점**
- **책임 분리**: UI와 로직을 분리하여 각각의 역할을 명확히 할 수 있습니다.
- **유연성 향상**: 로직을 상위 컴포넌트에서 처리하므로, 상태 관리나 **페이지 전환** 등을 더 유연하게 처리할 수 있습니다.
- **확장성**: 다른 상태나 로직을 연동하거나 다른 애니메이션 효과를 적용할 때 더 유연하게 처리할 수 있습니다.
- **UI만 담당**: 다른 UI 요소에 대한 처리가 필요할 때 쉽게 관리할 수 있습니다.

###### **단점**
- **상위 컴포넌트 복잡도 증가**: 상위 컴포넌트가 복잡해질 수 있습니다.
- **UI와 로직 연결 필요**: UI와 로직 간의 연결이 필요하고 관리가 번거로울 수 있습니다.

##### **✅ 최종 판단과 선택**
- **프로그레스바는 UI만 담당**해야 한다는 원칙을 바탕으로, 로직은 **상위 컴포넌트에서 처리**하는 방식으로 선택하였습니다.
- 이는 **책임 분리**와 **유연성**을 고려한 결정이었습니다.
- **상위 컴포넌트에서 로직을 처리**하면 **확장성과 유연성**이 더 용이하고, **UI는 `ProgressBar`에 집중**할 수 있습니다.

---

### 문제 1: **Progress Bar의 크기와 위치 불일치**
#### 🤔 배경
- 프로그레스바가 전체 리스트 뷰의 크기와 가로 길이를 갖고 있어 `TabButton`과 일치하지 않는 문제가 발생했습니다.

#### ✅ 해결: **크기와 위치 조정**
- `position: relative`와 `position: absolute`를 사용하여, `TabButton` 내에서 프로그레스바의 크기와 위치를 정확히 일치시켰습니다.
- 부모 요소에 맞춰 프로그레스바의 크기와 위치를 설정하여, 크기와 위치가 일치하도록 개선했습니다.

---

### 문제 2: **Progress Bar가 페이지 변경 시 동작하지 않음**
#### 🤔 배경
- 페이지 변경 시 프로그레스바가 동기화되지 않거나, 20초보다 빠르게 차오르는 문제가 발생했습니다.

#### ✅ 해결: **동기화된 Progress Bar 동작 구현**
- 페이지 변경과 프로그레스바 업데이트를 각각 독립적으로 관리하던 `setInterval`을 하나로 통합하여 코드 중복을 줄였습니다.
- 20초 동안 차오르는 시간을 정확하게 맞추기 위해 진척도를 계산하는 로직을 수정했습니다.
- **duration** 상수를 도입하여 시간 변경 시, **`duration`만 수정하면** 다른 시간으로도 쉽게 조정 가능하도록 했습니다.
- 페이지 변경 시마다 프로그레스바는 0%로 초기화되며, 설정된 시간 동안 차오르도록 동기화하여 동작하게 했습니다.
