### PR TITLE
✨ feat: api 연결, 응답 데이터에 따른 코드 로직 변경

### DIFF
--- a/src/components/Media/MediaSection/GridView/index.jsx
+++ b/src/components/Media/MediaSection/GridView/index.jsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from 'react';
-
 import GridView from './GridView';
 import Carousel from '../Carousel';
 import useCarousel from '../Carousel/useCarousel';
 
 const GridViewContainer = ({ data: pressList }) => {
-  const [totalPage, setTotalPage] = useState(0);
   const { currentPage, goNext, goPrev } = useCarousel();
 
   const ITEMS_PER_PAGE = 24;
@@ -16,18 +13,12 @@ const GridViewContainer = ({ data: pressList }) => {
 
   const selectedPressData = pressList.slice(startIndex, endIndex);
 
-  useEffect(() => {
-    const totalPageCount = Math.ceil(pressList.length / ITEMS_PER_PAGE);
-    const limitedPageCount = Math.min(totalPageCount, MAX_PAGE);
-    setTotalPage(limitedPageCount - 1);
-  }, [pressList]);
-
   return (
     <Carousel
       goNext={goNext}
       goPrev={goPrev}
       showPrev={currentPage > 0}
-      showNext={currentPage < totalPage}
+      showNext={currentPage < MAX_PAGE - 1}
     >
       <GridView data={selectedPressData} />
     </Carousel>

--- a/src/components/Media/index.jsx
+++ b/src/components/Media/index.jsx
@@ -27,7 +27,7 @@ const Media = () => {
       fetch(`http://localhost:5173/news/grid?limit=${LIMIT}`).then((res) =>
         res.json()
       ),
-      fetch('/mockData/mockData.json').then((res) => res.json()),
+      fetch('http://localhost:5173/news/list').then((res) => res.json()),
     ])
       .then(([grid, list]) => {
         setGridData(grid);

--- a/src/components/Media/index.jsx
+++ b/src/components/Media/index.jsx
@@ -11,6 +11,10 @@ const MediaContainer = styled.div`
   gap: 24px;
 `;
 
+const ITEMS_PER_PAGE = 24;
+const MAX_PAGE = 4;
+const LIMIT = ITEMS_PER_PAGE * MAX_PAGE;
+
 const Media = () => {
   const [gridData, setGridData] = useState([]);
   const [listData, setListData] = useState([]);
@@ -20,7 +24,9 @@ const Media = () => {
 
   useEffect(() => {
     Promise.all([
-      fetch('/mockData/pressList.json').then((res) => res.json()),
+      fetch(`http://localhost:5173/news/grid?limit=${LIMIT}`).then((res) =>
+        res.json()
+      ),
       fetch('/mockData/mockData.json').then((res) => res.json()),
     ])
       .then(([grid, list]) => {

--- a/src/components/NewsRolling/index.jsx
+++ b/src/components/NewsRolling/index.jsx
@@ -18,7 +18,7 @@ export default function NewsRolling() {
   }, [rollingNewsData]);
 
   useEffect(() => {
-    fetch('/mockData/rollingNews.json')
+    fetch('http://localhost:5173/news/rolling')
       .then((res) => res.json())
       .then(setRollingNewsData)
       .catch((err) => console.error('rollingNewsData fetch error:', err));

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,4 +21,10 @@ export default defineConfig({
       },
     ],
   },
+
+  server: {
+    proxy: {
+      '/news': 'http://localhost:3000', // Express 서버가 실행 중인 포트로 프록시 설정
+    },
+  },
 });


### PR DESCRIPTION
## 주요 변경 사항
- **API URL 변경**: 백엔드에서 제공하는 API로 URL을 변경하였습니다.
  - 기존에는 `mockdata`를 사용하여 데이터를 가져왔습니다.
  - 이제는 `grid` 데이터의 숫자가 최대 페이지 수만큼 전달되도록 변경되어, 관련 코드와 상태를 제거했습니다.

## 추후 리팩토링 예정 사항
- 현재 페이지네이션은 프론트엔드에서 처리되고 있습니다.
- 캐러셀 버튼 클릭 시 `currentPage`를 변경하여 그 상태에 맞는 fetch 요청을 진행하도록 변경할 예정입니다. 이후 페이지네이션 처리를 백엔드로 넘길 계획입니다.
- localHost~ 부분은 환경변수로 만들어서 추후 url이 변경될 때 api.config.js만 수정되게끔 할 계획입니다.
